### PR TITLE
Drop ambiguous python shebang

### DIFF
--- a/src/download_checkmd5.py
+++ b/src/download_checkmd5.py
@@ -1,4 +1,3 @@
-#!/bin/env python
 # Taken from Catkin's catkin_download under BSD-3
 # https://github.com/ros/catkin
 


### PR DESCRIPTION
This package invokes this script using the PYTHON_EXECUTABLE CMake variable, which may not be the same interpreter as would be used by the shebang embedded in the script, which is ignored during normal use.

This ambiguity is identified by the RHEL 9 builds as a bug.

https://build.ros2.org/view/Rbin_rhel_el964/job/Rbin_rhel_el964__ament_download__rhel_9_x86_64__binary/